### PR TITLE
feat: add storage adapters and docs

### DIFF
--- a/app/main/storage/files.ts
+++ b/app/main/storage/files.ts
@@ -1,0 +1,22 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+
+const UPLOAD_DIR = path.resolve(process.cwd(), 'packages/database/data/uploads')
+
+export async function uploadFile(filename: string, data: Buffer): Promise<void> {
+  await fs.mkdir(UPLOAD_DIR, { recursive: true })
+  await fs.writeFile(path.join(UPLOAD_DIR, filename), data)
+}
+
+export async function listFiles(): Promise<string[]> {
+  try {
+    const files = await fs.readdir(UPLOAD_DIR)
+    return files
+  } catch {
+    return []
+  }
+}
+
+export async function deleteFile(filename: string): Promise<void> {
+  await fs.rm(path.join(UPLOAD_DIR, filename), { force: true })
+}

--- a/app/main/storage/kv.ts
+++ b/app/main/storage/kv.ts
@@ -1,0 +1,44 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+
+const KV_FILE = path.resolve(process.cwd(), 'packages/database/data/kv.json')
+
+interface KVRecord {
+  [key: string]: unknown
+}
+
+let cache: KVRecord | null = null
+
+async function load(): Promise<KVRecord> {
+  if (cache) return cache
+  try {
+    const content = await fs.readFile(KV_FILE, 'utf-8')
+    cache = JSON.parse(content)
+  } catch {
+    cache = {}
+  }
+  return cache!
+}
+
+export async function get(key: string): Promise<unknown> {
+  const data = await load()
+  return data[key]
+}
+
+export async function set(key: string, value: unknown): Promise<void> {
+  const data = await load()
+  data[key] = value
+  await fs.mkdir(path.dirname(KV_FILE), { recursive: true })
+  await fs.writeFile(KV_FILE, JSON.stringify(data, null, 2))
+}
+
+export async function del(key: string): Promise<void> {
+  const data = await load()
+  delete data[key]
+  await fs.writeFile(KV_FILE, JSON.stringify(data, null, 2))
+}
+
+export async function list(): Promise<string[]> {
+  const data = await load()
+  return Object.keys(data)
+}

--- a/app/main/storage/mod.ts
+++ b/app/main/storage/mod.ts
@@ -1,0 +1,4 @@
+export * as files from './files'
+export * as kv from './kv'
+export * as postgres from './postgres'
+export * as vector from './vector'

--- a/app/main/storage/postgres.ts
+++ b/app/main/storage/postgres.ts
@@ -1,0 +1,25 @@
+let pool: any = null
+
+export async function connect(config: any): Promise<any> {
+  if (!pool) {
+    const { Pool } = await import('pg')
+    pool = new Pool(config)
+  }
+  return pool
+}
+
+export async function query<T = unknown>(text: string, params?: unknown[]): Promise<T[]> {
+  if (!pool) throw new Error('Postgres not connected')
+  const res = await pool.query(text, params)
+  return res.rows as T[]
+}
+
+export async function withClient<T>(fn: (client: any) => Promise<T>): Promise<T> {
+  if (!pool) throw new Error('Postgres not connected')
+  const client = await pool.connect()
+  try {
+    return await fn(client)
+  } finally {
+    client.release()
+  }
+}

--- a/app/main/storage/types.d.ts
+++ b/app/main/storage/types.d.ts
@@ -1,0 +1,1 @@
+declare module 'pg'

--- a/app/main/storage/vector.ts
+++ b/app/main/storage/vector.ts
@@ -1,0 +1,27 @@
+import OpenAI from 'openai'
+
+import { query } from './postgres'
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+
+export async function embed(text: string): Promise<number[]> {
+  const res = await openai.embeddings.create({ model: 'text-embedding-3-small', input: text })
+  return res.data[0].embedding
+}
+
+export async function storeEmbedding(text: string, metadata: Record<string, unknown> = {}): Promise<void> {
+  const embedding = await embed(text)
+  await query('INSERT INTO vectors (content, embedding, metadata) VALUES ($1, $2, $3)', [text, embedding, metadata])
+}
+
+export async function searchEmbedding(
+  text: string,
+  limit = 5
+): Promise<{ content: string; metadata: unknown; score: number }[]> {
+  const embedding = await embed(text)
+  const rows = await query<{ content: string; metadata: unknown; score: number }>(
+    'SELECT content, metadata, 1 - (embedding <=> $1) AS score FROM vectors ORDER BY embedding <=> $1 ASC LIMIT $2',
+    [embedding, limit]
+  )
+  return rows
+}

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,0 +1,26 @@
+# Storage
+
+## File Persistence
+
+```mermaid
+graph TD
+    A[Upload] -->|writes| B[Uploads Directory]
+    C[List] -->|reads| B
+    D[Delete] -->|removes| B
+```
+
+Files are stored under `packages/database/data/uploads` and can be uploaded, listed, or deleted through the storage APIs.
+
+## Vector Index
+
+```mermaid
+erDiagram
+    VECTORS {
+        int id PK
+        text content
+        vector embedding
+        json metadata
+    }
+```
+
+Embeddings are generated via OpenAI's `text-embedding-3-small` model and persisted in a Postgres table using the `pgvector` extension. Queries compute similarity with `<=>` distance.


### PR DESCRIPTION
## Summary
- add KV, Postgres and vector adapters under app/main/storage
- implement file upload, list and delete helpers
- document storage schemas

## Testing
- `npx eslint app/main/storage/*.ts`
- `yarn typecheck`

------
https://chatgpt.com/codex/tasks/task_b_68954b6920088332ac75130e2522b0ee