### PR TITLE
feat: add provider interface and OpenAI implementation

### DIFF
--- a/scripts/run-agents.js
+++ b/scripts/run-agents.js
@@ -1,55 +1,60 @@
 // Simple script to run agents.js from the database package
-const { execSync } = require('child_process');
-const path = require('path');
-const fs = require('fs');
+const { execSync } = require('child_process')
+const path = require('path')
+const fs = require('fs')
 
 try {
   // Get the absolute path to the database package directory
-  const databaseDir = path.resolve(__dirname, '..', 'packages', 'database');
-  const agentsPath = path.join(databaseDir, 'src', 'agents.js');
-  
+  const databaseDir = path.resolve(__dirname, '..', 'packages', 'database')
+  const agentsPath = path.join(databaseDir, 'src', 'agents.js')
+
   // Check if the file exists
   if (!fs.existsSync(agentsPath)) {
-    console.error(`Error: File not found at ${agentsPath}`);
-    process.exit(1);
+    console.error(`Error: File not found at ${agentsPath}`)
+    process.exit(1)
   }
-  
-  console.log('Installing dependencies for database package...');
-  
+
+  console.log('Installing dependencies for database package...')
+
   // Copy the required dependencies directly from the main node_modules
-  const mainNodeModules = path.resolve(__dirname, '..', 'node_modules');
-  const dbNodeModules = path.join(databaseDir, 'node_modules');
-  
+  const dbNodeModules = path.join(databaseDir, 'node_modules')
+
   // Ensure node_modules directory exists
   if (!fs.existsSync(dbNodeModules)) {
-    fs.mkdirSync(dbNodeModules, { recursive: true });
+    fs.mkdirSync(dbNodeModules, { recursive: true })
   }
-  
+
   // Let's create a simple implementation of the required modules
   if (!fs.existsSync(path.join(dbNodeModules, 'sqlite3'))) {
-    fs.mkdirSync(path.join(dbNodeModules, 'sqlite3'), { recursive: true });
-    fs.writeFileSync(path.join(dbNodeModules, 'sqlite3', 'index.js'), `
+    fs.mkdirSync(path.join(dbNodeModules, 'sqlite3'), { recursive: true })
+    fs.writeFileSync(
+      path.join(dbNodeModules, 'sqlite3', 'index.js'),
+      `
 module.exports = {
   Database: function() { return { run: function() {}, all: function() {} }; }
 };
-`);
+`
+    )
   }
-  
+
   if (!fs.existsSync(path.join(dbNodeModules, 'csv-parser'))) {
-    fs.mkdirSync(path.join(dbNodeModules, 'csv-parser'), { recursive: true });
-    fs.writeFileSync(path.join(dbNodeModules, 'csv-parser', 'index.js'), 'module.exports = function() { return { on: function() {} }; };');
+    fs.mkdirSync(path.join(dbNodeModules, 'csv-parser'), { recursive: true })
+    fs.writeFileSync(
+      path.join(dbNodeModules, 'csv-parser', 'index.js'),
+      'module.exports = function() { return { on: function() {} }; };'
+    )
   }
-  
-  console.log(`\nRunning agents script: ${agentsPath}`);
-  
+
+  console.log(`\nRunning agents script: ${agentsPath}`)
+
   // Execute the script directly using the Node.js executable with the full path in quotes
-  execSync(`node "${agentsPath}"`, { 
+  execSync(`node "${agentsPath}"`, {
     stdio: 'inherit',
     shell: true
-  });
-  
-  console.log('\nScript completed successfully');
+  })
+
+  console.log('\nScript completed successfully')
 } catch (error) {
-  console.error(`\nError: ${error.message}`);
-  process.exit(1);
+  console.error(`\nError: ${error.message}`)
+  process.exit(1)
 }

--- a/src/main/providers/LocalProvider.ts
+++ b/src/main/providers/LocalProvider.ts
@@ -1,0 +1,15 @@
+import { Provider } from './Provider'
+
+export class LocalProvider implements Provider {
+  async sendPrompt(prompt: string): Promise<string> {
+    // Placeholder for local model integration
+    void prompt
+    return 'Local provider not implemented.'
+  }
+
+  async streamResponse(prompt: string, onMessage: (chunk: string) => void): Promise<void> {
+    // Placeholder streaming implementation
+    void prompt
+    onMessage('Local provider not implemented.')
+  }
+}

--- a/src/main/providers/OpenAIProvider.ts
+++ b/src/main/providers/OpenAIProvider.ts
@@ -1,0 +1,73 @@
+import { Provider } from './Provider'
+
+interface OpenAIOptions {
+  apiKey: string
+  model?: string
+}
+
+export class OpenAIProvider implements Provider {
+  private readonly endpoint = 'https://api.openai.com/v1/chat/completions'
+  private readonly model: string
+
+  constructor(private readonly options: OpenAIOptions) {
+    this.model = options.model ?? 'gpt-4o-mini'
+  }
+
+  async sendPrompt(prompt: string): Promise<string> {
+    const res = await fetch(this.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.options.apiKey}`
+      },
+      body: JSON.stringify({
+        model: this.model,
+        messages: [{ role: 'user', content: prompt }]
+      })
+    })
+
+    const data = await res.json()
+    return data.choices?.[0]?.message?.content ?? ''
+  }
+
+  async streamResponse(prompt: string, onMessage: (chunk: string) => void): Promise<void> {
+    const res = await fetch(this.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.options.apiKey}`
+      },
+      body: JSON.stringify({
+        model: this.model,
+        messages: [{ role: 'user', content: prompt }],
+        stream: true
+      })
+    })
+
+    const reader = res.body?.getReader()
+    if (!reader) return
+
+    const decoder = new TextDecoder()
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+      const chunk = decoder.decode(value)
+      const lines = chunk
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean)
+      for (const line of lines) {
+        if (!line.startsWith('data:')) continue
+        const data = line.slice(5).trim()
+        if (data === '[DONE]') return
+        try {
+          const json = JSON.parse(data)
+          const text = json.choices?.[0]?.delta?.content
+          if (text) onMessage(text)
+        } catch {
+          // ignore malformed json
+        }
+      }
+    }
+  }
+}

--- a/src/main/providers/Provider.ts
+++ b/src/main/providers/Provider.ts
@@ -1,0 +1,12 @@
+export interface Provider {
+  /**
+   * Send a complete prompt and resolve with the full response.
+   */
+  sendPrompt(prompt: string): Promise<string>
+
+  /**
+   * Stream tokens from the model for the given prompt.
+   * The `onMessage` callback will be invoked with each new chunk.
+   */
+  streamResponse(prompt: string, onMessage: (chunk: string) => void): Promise<void>
+}

--- a/src/main/providers/index.ts
+++ b/src/main/providers/index.ts
@@ -1,0 +1,9 @@
+import { LocalProvider } from './LocalProvider'
+import { OpenAIProvider } from './OpenAIProvider'
+export type { Provider } from './Provider'
+export { LocalProvider, OpenAIProvider }
+
+export const providers = {
+  local: LocalProvider,
+  openai: OpenAIProvider
+}


### PR DESCRIPTION
## Summary
- define Provider interface with prompt and streaming methods
- add OpenAI provider using fetch streaming and a local provider stub
- register providers in a central registry and clean up run-agents script

## Testing
- `npx eslint src/main/providers/*.ts`
- `npx eslint scripts/run-agents.js`
- `yarn typecheck`
- `yarn test` *(fails: command not found: powershell.exe)*

------
https://chatgpt.com/codex/tasks/task_b_6895522b5e8083329129d42509dc32c7