### PR TITLE
feat: add summarization and translation tools

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,20 @@
+# Built-in Tools
+
+TykoTech exposes reusable tools that follow a simple command pattern. Each tool
+expects a `Provider` implementation that supplies the actual summarization or
+translation logic.
+
+## Example
+
+```ts
+import { execute } from '@main/tools'
+import type { Provider } from '@main/tools/provider'
+
+const provider: Provider = {
+  summarize: async (text) => `summary: ${text}`,
+  translate: async (text, target) => `${text} -> ${target}`
+}
+
+const summary = await execute('summarize', provider, 'Long text to summarize')
+const french = await execute('translate', provider, 'Hello world', 'fr')
+```

--- a/src/main/tools/index.ts
+++ b/src/main/tools/index.ts
@@ -1,0 +1,18 @@
+import type { Provider, ProviderCommand } from './provider'
+import { summarize } from './summarize'
+import { translate } from './translate'
+
+const commands: Record<string, ProviderCommand> = {
+  summarize: (provider: Provider, text: string) => summarize(provider, text),
+  translate: (provider: Provider, text: string, target: string) => translate(provider, text, target)
+}
+
+export function execute(command: string, ...args: any[]): Promise<any> {
+  const cmd = commands[command]
+  if (!cmd) {
+    return Promise.reject(new Error(`Unknown command: ${command}`))
+  }
+  return cmd(...(args as [Provider, ...any[]]))
+}
+
+export { commands, summarize, translate }

--- a/src/main/tools/provider.ts
+++ b/src/main/tools/provider.ts
@@ -1,0 +1,6 @@
+export interface Provider {
+  summarize(text: string): Promise<string>
+  translate(text: string, targetLanguage: string): Promise<string>
+}
+
+export type ProviderCommand = (provider: Provider, ...args: any[]) => Promise<any>

--- a/src/main/tools/summarize.ts
+++ b/src/main/tools/summarize.ts
@@ -1,0 +1,5 @@
+import type { Provider } from './provider'
+
+export async function summarize(provider: Provider, text: string): Promise<string> {
+  return provider.summarize(text)
+}

--- a/src/main/tools/translate.ts
+++ b/src/main/tools/translate.ts
@@ -1,0 +1,5 @@
+import type { Provider } from './provider'
+
+export async function translate(provider: Provider, text: string, targetLanguage: string): Promise<string> {
+  return provider.translate(text, targetLanguage)
+}


### PR DESCRIPTION
## Summary
- define `Provider` interface and command registry for invoking tools
- add `summarize` and `translate` implementations
- document tool usage in new `docs/tools.md`

## Testing
- `npx eslint src/main/tools && echo 'eslint succeeded'`
- `yarn typecheck:node && echo 'typecheck succeeded'`


------
https://chatgpt.com/codex/tasks/task_b_6895522bb4d48332a2085cbe8c754e81