### PR TITLE
feat(mcp): add basic MCP server and tests

### DIFF
--- a/app/mcp/server.test.ts
+++ b/app/mcp/server.test.ts
@@ -1,0 +1,53 @@
+//@vitest-environment node
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js'
+import { describe, expect, it } from 'vitest'
+
+import { createMcpServer } from './server'
+
+class MemoryTransport implements Transport {
+  peer?: MemoryTransport
+  onclose?: () => void
+  onerror?: (error: Error) => void
+  onmessage?: (message: JSONRPCMessage) => void
+  async start() {
+    /* noop */
+  }
+  async send(message: JSONRPCMessage) {
+    this.peer?.onmessage?.(message)
+  }
+  async close() {
+    this.onclose?.()
+  }
+}
+
+function createPair(): [MemoryTransport, MemoryTransport] {
+  const a = new MemoryTransport()
+  const b = new MemoryTransport()
+  a.peer = b
+  b.peer = a
+  return [a, b]
+}
+
+describe('MCP server', () => {
+  it('handles basic protocol flow', async () => {
+    const server = createMcpServer()
+    const client = new Client({ name: 'test-client', version: '1.0.0' })
+    const [serverTrans, clientTrans] = createPair()
+
+    await server.connect(serverTrans)
+    await client.connect(clientTrans)
+
+    const { tools } = await client.listTools({})
+    expect(tools.some((t) => t.name === 'echo')).toBe(true)
+
+    const resp = await client.callTool({ name: 'echo', arguments: { text: 'hi' } })
+    expect(resp.content?.[0]?.text).toBe('hi')
+
+    await client.ping()
+
+    await client.close()
+    await server.close()
+  })
+})

--- a/app/mcp/server.ts
+++ b/app/mcp/server.ts
@@ -1,0 +1,30 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { z } from 'zod'
+
+export function createMcpServer() {
+  const server = new McpServer({
+    name: 'cherry-mcp',
+    version: '0.1.0'
+  })
+
+  server.tool('echo', { text: z.string() }, async ({ text }) => ({
+    content: [{ type: 'text', text }]
+  }))
+
+  return server
+}
+
+export async function startMcpServer() {
+  const server = createMcpServer()
+  const transport = new StdioServerTransport()
+  await server.connect(transport)
+  return server
+}
+
+if (require.main === module) {
+  startMcpServer().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}

--- a/app/mcp/vitest.config.ts
+++ b/app/mcp/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['app/mcp/**/*.test.ts']
+  }
+})


### PR DESCRIPTION
## Summary
- add standalone MCP server with stdio transport and echo tool
- cover MCP session and tool invocation with in-memory transport tests
- configure vitest for new MCP test suite

## Testing
- `npx eslint app/mcp/server.ts app/mcp/server.test.ts app/mcp/vitest.config.ts`
- `yarn typecheck`
- `npx vitest run --config app/mcp/vitest.config.ts`


------
https://chatgpt.com/codex/tasks/task_b_68955506abc48332b6fc5f805df225e2