### PR TITLE
feat: add chat and file pages

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -15,6 +15,8 @@ import { ThemeProvider } from './context/ThemeProvider'
 import NavigationHandler from './handler/NavigationHandler'
 import AgentsPage from './pages/agents/AgentsPage'
 import AppsPage from './pages/apps/AppsPage'
+import ChatPage from './pages/chat/ChatPage'
+import FilePage from './pages/file/FilePage'
 import FilesPage from './pages/files/FilesPage'
 import HomePage from './pages/home/HomePage'
 import KnowledgePage from './pages/knowledge/KnowledgePage'
@@ -41,6 +43,8 @@ function App(): React.ReactElement {
                       <Route path="/paintings/*" element={<PaintingsRoutePage />} />
                       <Route path="/translate" element={<TranslatePage />} />
                       <Route path="/files" element={<FilesPage />} />
+                      <Route path="/chat" element={<ChatPage />} />
+                      <Route path="/file" element={<FilePage />} />
                       <Route path="/knowledge" element={<KnowledgePage />} />
                       <Route path="/apps" element={<AppsPage />} />
                       <Route path="/settings/*" element={<SettingsPage />} />

--- a/src/renderer/src/pages/chat/ChatPage.tsx
+++ b/src/renderer/src/pages/chat/ChatPage.tsx
@@ -1,0 +1,108 @@
+import { Button, Input, List, Select, Spin } from 'antd'
+import React, { useEffect, useState } from 'react'
+
+import type { Assistant } from '../../types'
+
+interface BackendMessage {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+}
+
+const ChatPage: React.FC = () => {
+  const [agents, setAgents] = useState<Assistant[]>([])
+  const [activeAgent, setActiveAgent] = useState<string>()
+  const [messages, setMessages] = useState<BackendMessage[]>([])
+  const [input, setInput] = useState('')
+  const [streaming, setStreaming] = useState(false)
+
+  useEffect(() => {
+    const loadAgents = async () => {
+      try {
+        const res = await fetch('/api/agents')
+        const data = await res.json()
+        setAgents(data)
+        setActiveAgent(data[0]?.id)
+      } catch (e) {
+        console.error(e)
+      }
+    }
+    loadAgents()
+  }, [])
+
+  useEffect(() => {
+    const loadMessages = async () => {
+      try {
+        const res = await fetch('/api/messages')
+        const data = await res.json()
+        setMessages(data)
+      } catch (e) {
+        console.error(e)
+      }
+    }
+    loadMessages()
+  }, [])
+
+  const handleSend = async () => {
+    if (!input.trim() || !activeAgent) return
+    const userMsg: BackendMessage = { id: Date.now().toString(), role: 'user', content: input }
+    setMessages((prev) => [...prev, userMsg])
+    setInput('')
+    setStreaming(true)
+    try {
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agentId: activeAgent, message: input })
+      })
+      const data: BackendMessage = await res.json()
+      setMessages((prev) => [...prev, data])
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setStreaming(false)
+    }
+  }
+
+  return (
+    <div style={{ padding: 16 }}>
+      <Select
+        style={{ width: 200, marginBottom: 16 }}
+        value={activeAgent}
+        onChange={setActiveAgent}
+        placeholder="Select agent">
+        {agents.map((a) => (
+          <Select.Option key={a.id} value={a.id}>
+            {a.name}
+          </Select.Option>
+        ))}
+      </Select>
+      <List
+        bordered
+        dataSource={messages}
+        style={{ height: 300, overflowY: 'auto', marginBottom: 16 }}
+        renderItem={(item) => (
+          <List.Item>
+            <strong>{item.role}:</strong>&nbsp;{item.content}
+          </List.Item>
+        )}
+      />
+      {streaming && (
+        <div style={{ marginBottom: 8 }}>
+          <Spin size="small" /> Streaming...
+        </div>
+      )}
+      <Input.TextArea
+        rows={3}
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        placeholder="Type your message"
+      />
+      <Button type="primary" onClick={handleSend} style={{ marginTop: 8 }}>
+        Send
+      </Button>
+    </div>
+  )
+}
+
+export default ChatPage

--- a/src/renderer/src/pages/file/FilePage.tsx
+++ b/src/renderer/src/pages/file/FilePage.tsx
@@ -1,0 +1,84 @@
+import { UploadOutlined } from '@ant-design/icons'
+import type { UploadProps } from 'antd'
+import { Modal, Tree, Upload } from 'antd'
+import type { DataNode } from 'antd/es/tree'
+import React, { useEffect, useState } from 'react'
+
+interface PreviewFile {
+  url: string
+  type: string
+}
+
+const FilePage: React.FC = () => {
+  const [treeData, setTreeData] = useState<DataNode[]>([])
+  const [preview, setPreview] = useState<PreviewFile | null>(null)
+
+  const loadFiles = async () => {
+    try {
+      const res = await fetch('/api/files')
+      const data = await res.json()
+      setTreeData(data)
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  useEffect(() => {
+    loadFiles()
+  }, [])
+
+  const uploadProps: UploadProps = {
+    name: 'file',
+    multiple: true,
+
+    customRequest: async (options: any) => {
+      const form = new FormData()
+      form.append('file', options.file as File)
+      try {
+        await fetch('/api/files/upload', {
+          method: 'POST',
+          body: form
+        })
+        options.onSuccess?.(null, options.file)
+        loadFiles()
+      } catch (e) {
+        console.error(e)
+        options.onError?.(e as Error)
+      }
+    }
+  }
+
+  const handleSelect = async (_: React.Key[], info: any) => {
+    if (info.node.isLeaf) {
+      try {
+        const res = await fetch(`/api/files/${info.node.key}`)
+        const blob = await res.blob()
+        const url = URL.createObjectURL(blob)
+        setPreview({ url, type: blob.type })
+      } catch (e) {
+        console.error(e)
+      }
+    }
+  }
+
+  return (
+    <div style={{ padding: 16 }}>
+      <Upload.Dragger {...uploadProps}>
+        <p className="ant-upload-drag-icon">
+          <UploadOutlined />
+        </p>
+        <p>Drag files here to upload</p>
+      </Upload.Dragger>
+      <Tree style={{ marginTop: 16 }} treeData={treeData} onSelect={handleSelect} />
+      <Modal open={!!preview} footer={null} onCancel={() => setPreview(null)} width={800}>
+        {preview?.type.startsWith('image/') ? (
+          <img src={preview.url} style={{ width: '100%' }} />
+        ) : (
+          <iframe src={preview?.url} style={{ width: '100%', height: '80vh' }} sandbox="" />
+        )}
+      </Modal>
+    </div>
+  )
+}
+
+export default FilePage


### PR DESCRIPTION
## Summary
- add basic ChatPage with agent switcher, message list, streaming indicator and input
- introduce FilePage to browse files, upload via drag-and-drop and preview content
- wire new ChatPage and FilePage routes into the app

## Testing
- `npx eslint src/renderer/src/pages/chat/ChatPage.tsx src/renderer/src/pages/file/FilePage.tsx src/renderer/src/App.tsx`
- `npx tsc --noEmit -p tsconfig.web.json`


------
https://chatgpt.com/codex/tasks/task_b_689562a8746883328c80476bdad394aa