### PR TITLE
chore: add compose and deno tasks

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -1,0 +1,3 @@
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts'
+
+serve(() => new Response('agent server running'), { port: 8080 })

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,17 @@
+services:
+  web:
+    image: denoland/deno:alpine
+    working_dir: /app
+    volumes:
+      - ./web:/app
+    command: deno task start
+    ports:
+      - "8000:8000"
+  background:
+    image: denoland/deno:alpine
+    working_dir: /app
+    volumes:
+      - ./background:/app
+    command: deno task start
+    ports:
+      - "8080:8080"

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,7 @@
+{
+  "tasks": {
+    "compile:windows": "deno compile --allow-all --target x86_64-pc-windows-msvc -o dist/background.exe background/main.ts && node scripts/copy-assets.mjs",
+    "compile:linux": "deno compile --allow-all --target x86_64-unknown-linux-gnu -o dist/background background/main.ts && node scripts/copy-assets.mjs",
+    "compile:mac": "deno compile --allow-all --target x86_64-apple-darwin -o dist/background-macos background/main.ts && node scripts/copy-assets.mjs"
+  }
+}

--- a/scripts/copy-assets.mjs
+++ b/scripts/copy-assets.mjs
@@ -1,0 +1,30 @@
+import fs from 'fs-extra'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const rootDir = path.resolve(__dirname, '..')
+const distDir = path.join(rootDir, 'dist')
+
+// Copy icon assets from build to dist/icons
+const iconsSrc = path.join(rootDir, 'build')
+const iconsDest = path.join(distDir, 'icons')
+fs.ensureDirSync(iconsDest)
+const iconFiles = ['icon.png', 'icon.ico', 'icon.icns', 'tray_icon.png', 'tray_icon_dark.png', 'tray_icon_light.png']
+iconFiles.forEach((file) => {
+  const src = path.join(iconsSrc, file)
+  if (fs.existsSync(src)) {
+    fs.copySync(src, path.join(iconsDest, file))
+  }
+})
+
+// Copy preload scripts
+const preloadSrc = path.join(rootDir, 'src', 'preload')
+const preloadDest = path.join(distDir, 'preload')
+if (fs.existsSync(preloadSrc)) {
+  fs.ensureDirSync(preloadDest)
+  fs.copySync(preloadSrc, preloadDest, { overwrite: true })
+}
+
+console.log('Assets copied to dist directory')


### PR DESCRIPTION
## Summary
- add docker compose with web and background services
- add cross-platform deno compile tasks
- copy icons and preload scripts to build output

## Testing
- `npx eslint scripts/copy-assets.mjs background/main.ts --fix`
- `yarn typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68973695cad083329df83d7f3271dd56