### PR TITLE
chore: add dev branch CI

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,63 @@
+name: Dev CI
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v1.x
+      - run: deno lint
+
+  type-check:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v1.x
+      - run: deno check ./
+
+  test:
+    runs-on: ubuntu-latest
+    needs: type-check
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v1.x
+      - run: deno test
+
+  build:
+    runs-on: ${{ matrix.os }}
+    needs: test
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: cherryFork-linux
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: cherryFork-macos
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact: cherryFork-windows.exe
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v1.x
+      - run: deno compile --target ${{ matrix.target }} -o ${{ matrix.artifact }} src/main/index.ts
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+          retention-days: 7


### PR DESCRIPTION
## Summary
- add Dev CI workflow for `dev` branch

## Testing
- `yarn lint` *(fails: /workspace/cherryFork/scripts/run-agents.js 20:9  error  'mainNodeModules' is assigned a value but never used)*
- `yarn typecheck`
- `yarn test` *(fails: command not found: powershell.exe)*

------
https://chatgpt.com/codex/tasks/task_b_68973695f8dc83329103f41843a3f201