### PR TITLE
feat: add web component routes and screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ local
 coverage
 .vitest-cache
 vitest.config.*.timestamp-*
+
+# Screenshot outputs
+docs/screenshots/*.png

--- a/app/renderer/components/CustomTag.tsx
+++ b/app/renderer/components/CustomTag.tsx
@@ -1,0 +1,66 @@
+import { CloseOutlined } from '@ant-design/icons'
+import { Tooltip } from 'antd'
+import { FC, memo, useMemo } from 'react'
+
+interface CustomTagProps {
+  icon?: React.ReactNode
+  children?: React.ReactNode | string
+  color: string
+  size?: number
+  tooltip?: string
+  closable?: boolean
+  onClose?: () => void
+}
+
+const CustomTag: FC<CustomTagProps> = ({ children, icon, color, size = 12, tooltip, closable = false, onClose }) => {
+  const tagContent = useMemo(() => {
+    const tagStyle: React.CSSProperties = {
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: 4,
+      padding: `${size / 3}px ${size * 0.8}px`,
+      paddingRight: closable ? `${size * 1.8}px` : `${size * 0.8}px`,
+      borderRadius: 99,
+      color,
+      backgroundColor: `${color}20`,
+      fontSize: size,
+      lineHeight: 1,
+      whiteSpace: 'nowrap',
+      position: 'relative'
+    }
+
+    const closeIconStyle: React.CSSProperties = {
+      cursor: 'pointer',
+      fontSize: size * 0.8,
+      color,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      position: 'absolute',
+      right: size * 0.2,
+      top: size * 0.2,
+      bottom: size * 0.2,
+      borderRadius: 99,
+      transition: 'all 0.2s ease',
+      aspectRatio: '1',
+      lineHeight: 1
+    }
+
+    return (
+      <div style={tagStyle}>
+        {icon} {children}
+        {closable && <CloseOutlined style={closeIconStyle} onClick={onClose} />}
+      </div>
+    )
+  }, [children, closable, color, icon, onClose, size])
+
+  return tooltip ? (
+    <Tooltip title={tooltip} placement="top" mouseEnterDelay={0.3}>
+      {tagContent}
+    </Tooltip>
+  ) : (
+    tagContent
+  )
+}
+
+export default memo(CustomTag)

--- a/app/renderer/components/DividerWithText.tsx
+++ b/app/renderer/components/DividerWithText.tsx
@@ -1,0 +1,15 @@
+import { CSSProperties } from 'react'
+
+interface DividerWithTextProps {
+  text: string
+  style?: CSSProperties
+}
+
+export default function DividerWithText({ text, style }: DividerWithTextProps) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', margin: '0px 0', ...style }}>
+      <span style={{ fontSize: 12, color: 'var(--color-text-2)', marginRight: 8 }}>{text}</span>
+      <div style={{ flex: 1, height: 1, backgroundColor: 'var(--color-border)' }} />
+    </div>
+  )
+}

--- a/app/renderer/components/index.ts
+++ b/app/renderer/components/index.ts
@@ -1,0 +1,2 @@
+export { default as CustomTag } from './CustomTag'
+export { default as DividerWithText } from './DividerWithText'

--- a/app/routes/chat.tsx
+++ b/app/routes/chat.tsx
@@ -1,0 +1,10 @@
+import { CustomTag } from '../renderer/components'
+
+export default function Chat() {
+  return (
+    <main className="p-4">
+      <h1>Chat</h1>
+      <CustomTag color="#007bff">Hello</CustomTag>
+    </main>
+  )
+}

--- a/app/routes/files.tsx
+++ b/app/routes/files.tsx
@@ -1,0 +1,8 @@
+export default function Files() {
+  return (
+    <main className="p-4">
+      <h1>Files</h1>
+      <p>File management coming soon.</p>
+    </main>
+  )
+}

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -1,0 +1,8 @@
+export default function Settings() {
+  return (
+    <main className="p-4">
+      <h1>Settings</h1>
+      <p>Adjust your preferences here.</p>
+    </main>
+  )
+}

--- a/docs/screenshots/chat.html
+++ b/docs/screenshots/chat.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Chat Preview</title>
+</head>
+<body>
+<main style="padding:16px">
+  <h1>Chat</h1>
+  <div style="display:inline-flex;align-items:center;gap:4px;padding:4px 10px;border-radius:99px;color:#007bff;background-color:#007bff20;font-size:12px;line-height:1;white-space:nowrap;position:relative;">Hello</div>
+</main>
+</body>
+</html>

--- a/scripts/run-agents.js
+++ b/scripts/run-agents.js
@@ -1,55 +1,60 @@
 // Simple script to run agents.js from the database package
-const { execSync } = require('child_process');
-const path = require('path');
-const fs = require('fs');
+const { execSync } = require('child_process')
+const path = require('path')
+const fs = require('fs')
 
 try {
   // Get the absolute path to the database package directory
-  const databaseDir = path.resolve(__dirname, '..', 'packages', 'database');
-  const agentsPath = path.join(databaseDir, 'src', 'agents.js');
-  
+  const databaseDir = path.resolve(__dirname, '..', 'packages', 'database')
+  const agentsPath = path.join(databaseDir, 'src', 'agents.js')
+
   // Check if the file exists
   if (!fs.existsSync(agentsPath)) {
-    console.error(`Error: File not found at ${agentsPath}`);
-    process.exit(1);
+    console.error(`Error: File not found at ${agentsPath}`)
+    process.exit(1)
   }
-  
-  console.log('Installing dependencies for database package...');
-  
+
+  console.log('Installing dependencies for database package...')
+
   // Copy the required dependencies directly from the main node_modules
-  const mainNodeModules = path.resolve(__dirname, '..', 'node_modules');
-  const dbNodeModules = path.join(databaseDir, 'node_modules');
-  
+  const dbNodeModules = path.join(databaseDir, 'node_modules')
+
   // Ensure node_modules directory exists
   if (!fs.existsSync(dbNodeModules)) {
-    fs.mkdirSync(dbNodeModules, { recursive: true });
+    fs.mkdirSync(dbNodeModules, { recursive: true })
   }
-  
+
   // Let's create a simple implementation of the required modules
   if (!fs.existsSync(path.join(dbNodeModules, 'sqlite3'))) {
-    fs.mkdirSync(path.join(dbNodeModules, 'sqlite3'), { recursive: true });
-    fs.writeFileSync(path.join(dbNodeModules, 'sqlite3', 'index.js'), `
+    fs.mkdirSync(path.join(dbNodeModules, 'sqlite3'), { recursive: true })
+    fs.writeFileSync(
+      path.join(dbNodeModules, 'sqlite3', 'index.js'),
+      `
 module.exports = {
   Database: function() { return { run: function() {}, all: function() {} }; }
 };
-`);
+`
+    )
   }
-  
+
   if (!fs.existsSync(path.join(dbNodeModules, 'csv-parser'))) {
-    fs.mkdirSync(path.join(dbNodeModules, 'csv-parser'), { recursive: true });
-    fs.writeFileSync(path.join(dbNodeModules, 'csv-parser', 'index.js'), 'module.exports = function() { return { on: function() {} }; };');
+    fs.mkdirSync(path.join(dbNodeModules, 'csv-parser'), { recursive: true })
+    fs.writeFileSync(
+      path.join(dbNodeModules, 'csv-parser', 'index.js'),
+      'module.exports = function() { return { on: function() {} }; };'
+    )
   }
-  
-  console.log(`\nRunning agents script: ${agentsPath}`);
-  
+
+  console.log(`\nRunning agents script: ${agentsPath}`)
+
   // Execute the script directly using the Node.js executable with the full path in quotes
-  execSync(`node "${agentsPath}"`, { 
+  execSync(`node "${agentsPath}"`, {
     stdio: 'inherit',
     shell: true
-  });
-  
-  console.log('\nScript completed successfully');
+  })
+
+  console.log('\nScript completed successfully')
 } catch (error) {
-  console.error(`\nError: ${error.message}`);
-  process.exit(1);
+  console.error(`\nError: ${error.message}`)
+  process.exit(1)
 }


### PR DESCRIPTION
## Summary
- introduce shared web components mirroring existing renderer components
- add initial Fresh-style routes for chat, files, and settings
- generate responsive chat screenshots without committing image assets
- clean up run-agents script and ignore generated screenshots

## Testing
- `npx eslint scripts/run-agents.js`
- `yarn typecheck`
- `npx --yes playwright screenshot --browser=chromium --viewport-size=375,812 docs/screenshots/chat.html docs/screenshots/chat-mobile.png`
- `npx --yes playwright screenshot --browser=chromium --viewport-size=1280,720 docs/screenshots/chat.html docs/screenshots/chat-desktop.png`

------
https://chatgpt.com/codex/tasks/task_b_689562a7d5cc833286d6d21014523ce4